### PR TITLE
Queue name can be made mandatory

### DIFF
--- a/background_task/settings.py
+++ b/background_task/settings.py
@@ -58,4 +58,9 @@ class AppSettings(object):
             prefix = '-'
         return prefix
 
+    @property
+    def BACKGROUND_TASK_QUEUE_NAME_REQUIRED(self):
+        """Enforce that every Task should belong to a queue when calling the decorator."""
+        return getattr(settings, 'BACKGROUND_TASK_QUEUE_NAME_REQUIRED', False)
+
 app_settings = AppSettings()

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -219,6 +219,9 @@ class DBTaskRunner(object):
                  verbose_name=None, creator=None,
                  repeat=None, repeat_until=None, remove_existing_tasks=False):
         '''Simply create a task object in the database'''
+        if app_settings.BACKGROUND_TASK_QUEUE_NAME_REQUIRED and not queue:
+            raise RuntimeError("The required field queue was not provided")
+
         task = Task.objects.new_task(task_name, args, kwargs, run_at, priority,
                                      queue, verbose_name, creator, repeat,
                                      repeat_until, remove_existing_tasks)


### PR DESCRIPTION
A new setting has been added that enables this new behaviour: `BACKGROUND_TASK_QUEUE_NAME_REQUIRED`.

When False, it has no effect on scheduling tasks.

When True, attempting to schedule a task will raise a RuntimeError if no queue name is supplied.

This change would be better enforced at the database-level, but I didn't want to introduce new migrations into this project. Existing Tasks and CompletedTasks are not affected by this change.