### PR TITLE
Add process tasks exclude queue option

### DIFF
--- a/background_task/management/commands/process_tasks.py
+++ b/background_task/management/commands/process_tasks.py
@@ -52,6 +52,11 @@ class Command(BaseCommand):
             'dest': 'queue',
             'help': 'Only process tasks on this named queue',
         }),
+        (('--exclude-queue', ), {
+            'action': 'store',
+            'dest': 'exclude_queue',
+            'help': 'Don\'t process tasks on this named queue',
+        }),
         (('--log-std', ), {
             'action': 'store_true',
             'dest': 'log_std',
@@ -82,6 +87,7 @@ class Command(BaseCommand):
         duration = options.get('duration', 0)
         sleep = options.get('sleep', 5.0)
         queue = options.get('queue', None)
+        exclude_queue = options.get('exclude_queue', None)
         log_std = options.get('log_std', False)
         is_dev = options.get('dev', False)
         sig_manager = self.sig_manager
@@ -102,7 +108,7 @@ class Command(BaseCommand):
                 # shutting down gracefully
                 break
 
-            if not self._tasks.run_next_task(queue):
+            if not self._tasks.run_next_task(queue=queue, exclude_queue=exclude_queue):
                 # there were no tasks in the queue, let's recover.
                 close_connection()
                 logger.debug('waiting for tasks')

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -44,11 +44,13 @@ class TaskManager(models.Manager):
     def created_by(self, creator):
         return self.get_queryset().created_by(creator)
 
-    def find_available(self, queue=None):
+    def find_available(self, queue=None, exclude_queue=None):
         now = timezone.now()
         qs = self.unlocked(now)
         if queue:
             qs = qs.filter(queue=queue)
+        if exclude_queue:
+            qs = qs.exclude(queue=exclude_queue)
         ready = qs.filter(run_at__lte=now, failed_at=None)
         _priority_ordering = '{}priority'.format(app_settings.BACKGROUND_TASK_PRIORITY_ORDERING)
         ready = ready.order_by(_priority_ordering, 'run_at')

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -134,8 +134,8 @@ class Tasks(object):
         else:
             self._bg_runner(proxy_task, task, *args, **kwargs)
 
-    def run_next_task(self, queue=None):
-        return self._runner.run_next_task(self, queue)
+    def run_next_task(self, queue=None, exclude_queue=None):
+        return self._runner.run_next_task(self, queue=queue, exclude_queue=exclude_queue)
 
 
 class TaskSchedule(object):
@@ -241,9 +241,9 @@ class DBTaskRunner(object):
         signals.task_created.send(sender=self.__class__, task=task)
         return task
 
-    def get_task_to_run(self, tasks, queue=None):
+    def get_task_to_run(self, tasks, queue=None, exclude_queue=None):
         try:
-            available_tasks = [task for task in Task.objects.find_available(queue)
+            available_tasks = [task for task in Task.objects.find_available(queue=queue, exclude_queue=exclude_queue)
                                if task.task_name in tasks._tasks][:5]
             for task in available_tasks:
                 # try to lock task
@@ -258,8 +258,8 @@ class DBTaskRunner(object):
         logger.info('Running %s', task)
         tasks.run_task(task)
 
-    def run_next_task(self, tasks, queue=None):
-        task = self.get_task_to_run(tasks, queue)
+    def run_next_task(self, tasks, queue=None, exclude_queue=None):
+        task = self.get_task_to_run(tasks, queue=queue, exclude_queue=exclude_queue)
         if task:
             self.run_task(tasks, task)
             return True


### PR DESCRIPTION
I want to be able to run one process for only matchmaking, and another process for all other tasks.

This PR adds a new flag to exclude a single queue name.

A future improvement to this package might be to make both --queue and --exclude-queue accept multiple named queues.